### PR TITLE
DAI-482 Viral-loops script strategy updated to beforeInteractive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+*.un~
+*.tsx~
+
+# Vim
+*.swp

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -82,7 +82,7 @@ fbq('track', 'PageView');
         </Script>
         <Script
           src="https://app.viral-loops.com/widgetsV2/core/loader.js"
-          strategy="lazyOnload"
+          strategy="beforeInteractive"
         />
       </head>
       <body className={`${ubuntu.className} grid`}>


### PR DESCRIPTION
This pull request addresses the issue identified in DAI-482. The strategy for the viral-loops script has been updated to `beforeInteractive` in order to optimize performance and ensure proper loading behavior. 

The changes were made in the `static-update` branch and are now ready to be merged into the `static-design` branch. This update is expected to enhance the user experience by making the page more responsive and reducing the load time.

Please review the changes and if everything looks good, feel free to merge this pull request. If there are any issues or further changes needed, kindly provide your feedback.

Thank you for your time and consideration.
